### PR TITLE
Fixes for handling max_time

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 from dwave.system.composites import EmbeddingComposite
 from dwave.system.samplers import DWaveSampler
 
-from job_shop_scheduler import get_jss_bqm
+from job_shop_scheduler import get_jss_bqm, is_auxiliary_variable
 
 # Construct a BQM for the jobs
 jobs = {"cupcakes": [("mixer", 2), ("oven", 1)],
@@ -62,6 +62,8 @@ selected_nodes = [k for k, v in solution.items() if v == 1]
 # Parse node information
 task_times = {k: [-1]*len(v) for k, v in jobs.items()}
 for node in selected_nodes:
+    if is_auxiliary_variable(node):
+        continue
     job_name, task_time = node.rsplit("_", 1)
     task_index, start_time = map(int, task_time.split(","))
 

--- a/job_shop_scheduler.py
+++ b/job_shop_scheduler.py
@@ -14,6 +14,7 @@
 
 from __future__ import print_function
 
+from re import match
 from bisect import bisect_right
 
 import dwavebinarycsp
@@ -356,3 +357,11 @@ class JobShopScheduler:
 
         return bqm
 
+
+def is_auxiliary_variable(v):
+    """Check whether named variable is an auxiliary variable.
+
+    Auxiliary variables may be added as part of converting the
+    constraint satisfaction problem to a BQM.
+    """
+    return match("aux\d+$", v)

--- a/job_shop_scheduler.py
+++ b/job_shop_scheduler.py
@@ -177,6 +177,9 @@ class JobShopScheduler:
 
         if self.max_time is None:
             self.max_time = total_time
+        elif self.max_time > total_time:
+            print('Warning, max_time will be reduced to worst case total time:', total_time)
+            self.max_time = total_time
         self.max_time -= 1    # -1 to account for zero-indexing
 
     def _add_one_start_constraint(self):

--- a/tests/test_job_shop_scheduler.py
+++ b/tests/test_job_shop_scheduler.py
@@ -85,12 +85,12 @@ class TestIndividualJSSConstraints(unittest.TestCase):
 
     def test_precedenceConstraint(self):
         jobs = {0: [("m1", 2), ("m2", 1)]}
-        max_time = 4
+        max_time = 3
         jss = JobShopScheduler(jobs, max_time)
         jss._add_precedence_constraint()
 
         # Task 0_0 starts after task 0_1
-        backward_solution = {"0_0,3": 1, "0_1,0": 1}
+        backward_solution = {"0_0,2": 1, "0_1,0": 1}
         fill_with_zeros(backward_solution, jobs, max_time)
 
         # Tasks start at the same time
@@ -168,7 +168,7 @@ class TestCombinedJSSConstraints(unittest.TestCase):
     def test_relaxedSchedule(self):
         jobs = {"breakfast": [("cook", 2), ("eat", 1)],
                 "music": [("play", 2)]}
-        max_time = 7
+        max_time = 5
         jss = JobShopScheduler(jobs, max_time)
         jss.get_bqm()   # Run job shop scheduling constraints
 

--- a/tests/test_job_shop_scheduler.py
+++ b/tests/test_job_shop_scheduler.py
@@ -219,7 +219,7 @@ class TestJSSExactSolverResponse(unittest.TestCase):
         jss = JobShopScheduler(jobs, max_time)
         bqm = jss.get_bqm()
         response = ExactSolver().sample(bqm)
-        response_sample = next(response.samples())
+        response_sample = response.first.sample
 
         # Verify that response_sample obeys constraints
         self.assertTrue(jss.csp.check(response_sample))
@@ -240,7 +240,7 @@ class TestJSSExactSolverResponse(unittest.TestCase):
         jss = JobShopScheduler(jobs, max_time)
         bqm = jss.get_bqm()
         response = ExactSolver().sample(bqm)
-        response_sample = next(response.samples())
+        response_sample = response.first.sample
 
         # Verify that response_sample obeys constraints
         self.assertTrue(jss.csp.check(response_sample))

--- a/tests/test_job_shop_scheduler.py
+++ b/tests/test_job_shop_scheduler.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from itertools import product
-from re import match
 import sys
 import unittest
 if sys.version_info.major < 3:
@@ -26,7 +25,7 @@ import dwavebinarycsp
 from dwavebinarycsp.exceptions import ImpossibleBQM
 from tabu import TabuSampler
 
-from job_shop_scheduler import JobShopScheduler, get_jss_bqm
+from job_shop_scheduler import JobShopScheduler, get_jss_bqm, is_auxiliary_variable
 
 
 def fill_with_zeros(expected_solution_dict, job_dict, max_time):
@@ -49,7 +48,7 @@ def fill_with_zeros(expected_solution_dict, job_dict, max_time):
 
 def get_energy(solution_dict, bqm):
     min_energy = float('inf')
-    aux_variables = [v for v in bqm.variables if match("aux\d+$", v)]
+    aux_variables = [v for v in bqm.variables if is_auxiliary_variable(v)]
 
     # Try all possible values of auxiliary variables
     for aux_values in product([0, 1], repeat=len(aux_variables)):
@@ -199,14 +198,14 @@ class TestJSSExactSolverResponse(unittest.TestCase):
 
         # Check that common variables match
         for key in common_keys:
-            if match('aux\d+$', key):
+            if is_auxiliary_variable(key):
                 continue
 
             self.assertEqual(response[key], expected[key], "Failed on key {}".format(key))
 
         # Check that non-existent 'sample' variables are 0
         for key in different_keys:
-            if match('aux\d+$', key):
+            if is_auxiliary_variable(key):
                 continue
 
             self.assertEqual(response[key], 0, "Failed on key {}".format(key))


### PR DESCRIPTION
A couple fixes:
- Skip auxiliary variables when post-processing solution in demo.py.  Closes #9.
- Reduce max_time (and issue warning) when the value exceeds worst case total time.  This eliminates `ImpossibleBQM` exception that can occur when converting the CSP to BQM.  This probably addresses #7, depending on what exactly was causing the original reporter's issue.

And go ahead and fix a `DeprecationWarning` with extracting the results.